### PR TITLE
RIN-751 - Send client message back to local websocket.

### DIFF
--- a/lib/connect-service/websocket.js
+++ b/lib/connect-service/websocket.js
@@ -82,6 +82,9 @@ function newWebSocket(response, server) {
           // happen on the Drupal FE.
           thisWS.on('message', function (data) {
             console.log(`Message recieved from client: ${ data }`);
+            // Send the message BACK to the client so any
+            // subscribers also receive the message.
+            sendClientsMessage(data, localWSS);
           });
 
           thisWS.on('close', function () {


### PR DESCRIPTION
Send client message back to local websocket so we can listen for it on the Drupal side.