### PR TITLE
Feature/zhawkins/update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # node_dss
 
-## Getting Started
+## Getting Started 🛠
 
 Use the specified version of Node via NVM.
 
 `nvm use`
 
-If you haven't, add the local config and htpasswd files not in the repo.
+If you haven't, add the local config, server config and htpasswd files not in the repo.
+
+Anything within `config.local.json` will only apply to your local environment. Anything within `config.json` will be deployed to develop or production environments.
+
+`config.local.json` -> `./config/config.local.json`
 
 `config.json` -> `./config/config.json`
 
@@ -15,3 +19,7 @@ If you haven't, add the local config and htpasswd files not in the repo.
 Start up the server.
 
 `npm watch`
+
+## Deploying ✈️
+
+Check out the [docs](https://codeandtheory.atlassian.net/wiki/display/RIN/DSS) for more information.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "watch": "node server.js",
     "build": "next build",
-    "start": "npm run build && NODE_ENV=production node server.js"
+    "start": "NODE_ENV=production node server.js"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
- Updates readme to reference config.local.json and point to the confluence docs.
- Remove the build from start as it happens on deploy and doesn't need to be done twice.