### PR TITLE
Build fails if we don't run it on EB.

### DIFF
--- a/deploy/deploy_aws.sh
+++ b/deploy/deploy_aws.sh
@@ -3,7 +3,7 @@
 # This script will compile this application and then deploy it
 # to AWS Elastic Beanstalk.
 #
-# Run like `./deploy/deploy_aws.sh Sample-env-1`.
+# Run like `./deploy/deploy_aws.sh AylaDSS-develop`.
 #
 # to the `my_eb_app-production` environment of the `my_eb_app` EB application.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "watch": "node server.js",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js"
+    "start": "npm run build && NODE_ENV=production node server.js"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
Build fails if we don't run it on EB sooooo add it to the script run on the EB side of the deploy.