### PR TITLE
Feature/zhawkins/rin 916  ayla reconnect

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,7 @@ env:
 
   # Define globals exposed by Node.js.
   node: true
+  es6: true
 
 # Inherit settings from ESLint Recommended config.
 # Rules above override any rules configured here.

--- a/lib/connect-service/websocket.js
+++ b/lib/connect-service/websocket.js
@@ -1,8 +1,7 @@
-'use strict';
-
 const WebSocket = require('ws');
 const endpoint = require('./endpoint');
 let timer = '';
+let responseTimer = null;
 
 /**
  * Send message to clients connected to the local WebSocket Server.
@@ -30,6 +29,55 @@ function sendClientsMessage(data, localWSS) {
       }
     }
   );
+}
+
+/**
+ * Attempt to reconnect to the Ayla WebSocket stream.
+ *
+ * @param {object} response
+ *  - Object containing details about subscription status.
+ * @param {object} localWSS
+ *  - Local WebSocket server with the clients that need to receive the message.
+ * @param {function} newWebSocket
+ *  - callback function to run to reconnect service.
+ * @param {object} server
+ *  - Server to create the local websocket from.
+ *
+ * @return {undefined}
+ */
+function reconnect(response, localWSS, newWebSocket, server) {
+  let timerCounter = 0;
+  console.warn('=== reconnecting service ===');
+
+  // Let the client know the Ayla WebSocket stream has closed.
+  const connected = JSON.stringify({
+    connected: false
+  });
+
+  // Send message to clients.
+  sendClientsMessage(connected, localWSS);
+
+  // Close the current open WebSocket server.
+  localWSS.close();
+
+  // Attempt to reconnect to the service.
+  // Try every 30 seconds per Ayla recommendations.
+  timer = setInterval(() => {
+    timerCounter++;
+    console.info(`attempting to reconnect...${ timerCounter }`);
+    // Limit the retries to 5.
+    if (timerCounter === 5) {
+      clearInterval(timer);
+    }
+    // Attempt to connect again.
+    newWebSocket(response, server)
+      .then((response) => {
+        console.log(response);
+      })
+      .catch(function (reason) {
+        return reason;
+      });
+  }, 30000);
 }
 
 /**
@@ -77,9 +125,6 @@ function newWebSocket(response, server) {
           });
           sendClientsMessage(connected, localWSS);
 
-          // @todo: this doesn't need to exist here and is only here
-          // for testing. The actual functionality needs to
-          // happen on the Drupal FE.
           thisWS.on('message', function (data) {
             console.log(`Message recieved from client: ${ data }`);
             // Send the message BACK to the client so any
@@ -93,43 +138,30 @@ function newWebSocket(response, server) {
         });
 
         aylaWS.on('close', function close() {
-          let timerCounter = 0;
           console.warn('=== websocket closed ===');
 
-          // Let the client know the Ayla WebSocket stream has closed.
-          const connected = JSON.stringify({
-            connected: false
-          });
+          // Clear any pending response timers so we don't try to reconnect
+          // in multiple places at the same time.
+          clearTimeout(responseTimer);
 
-          // Send message to clients.
-          sendClientsMessage(connected, localWSS);
-
-          // Close the current open WebSocket server.
-          localWSS.close();
-
-          // Attempt to reconnect to the service.
-          // Try every 30 seconds per Ayla recommendations.
-          timer = setInterval(() => {
-            timerCounter++;
-            console.info(`attempting to reconnect...${ timerCounter }`);
-            // Limit the retries to 5.
-            if (timerCounter === 5) {
-              clearInterval(timer);
-            }
-            // Attempt to connect again.
-            newWebSocket(response);
-          }, 30000);
+          // Attempt reconnect.
+          reconnect(response, localWSS, newWebSocket, server);
         });
 
         // Send message data from Ayla WS to the local WS on the client.
         aylaWS.on('message', function incoming(data) {
+
+          // Clear any timers checking to make sure messages are returned.
+          clearTimeout(responseTimer);
+
           console.info('====== Ayla message received ======');
 
           // Format the data into a useable array.
           const messageData = data.split('|');
 
           // If the first message element is a "1" then this is a heartbeat and
-          // not actual data. Respond to the service so it knows we're listening.
+          // not actual data. Respond to the service so it knows
+          // we're listening.
           if (messageData[0] === '1') {
             // The service needs us to reply to the heartbeat in order to
             // keep the websocket open.
@@ -160,6 +192,13 @@ function newWebSocket(response, server) {
             // Send the client a message.
             sendClientsMessage(messageData[1], localWSS);
           }
+
+          // If no new messages have been received after 120 seconds
+          // the connection must be closed. Attempt to
+          // reconnect to the service.
+          responseTimer = setTimeout(() => {
+            reconnect(response, localWSS, newWebSocket, server);
+          }, 120000);
 
           // Get the time difference between heartbeats.
           // @todo: Double check this is the correct time diff for the aylaWS.on()


### PR DESCRIPTION
- Updates eslintrc to new format.
- Adds ES6 support for ESlinter.
- Removes unnecessary `use strict`. `use strict` isn't needed if it's in a module.
- Moves reconnect functionality into it's own function.
- Adds timeout that attempts to reconnect if Ayla has not responded for 120 seconds.
