### PR TITLE
Feature/zhawkins/cache bust get

### DIFF
--- a/lib/connect-service/endpoint.js
+++ b/lib/connect-service/endpoint.js
@@ -28,7 +28,8 @@ module.exports = {
       + encodeURIComponent(urlValues.dsn)
       + '/'
       + encodeURIComponent(urlValues.property_name)
-      + '?_format=json';
+      + '?_format=json'
+      + '&ts=' + Date.now();
 
     console.info(endpointURL);
 

--- a/lib/connect-service/subscription.js
+++ b/lib/connect-service/subscription.js
@@ -109,7 +109,7 @@ module.exports = {
         // Loop through the last three results and see if there's
         // an unused subscription we can reuse.
         for (let num = 1; num <= 3; num++) {
-          if (response[response.length - num].subscription.connection_status !== 'Online') {
+          if (response[response.length - num] && response[response.length - num].subscription.connection_status !== 'Online') {
             lastSubscription = response[response.length - num];
             break;
           }

--- a/lib/connect-service/websocket.js
+++ b/lib/connect-service/websocket.js
@@ -180,17 +180,21 @@ function newWebSocket(response, server) {
           // relevant information.
           else {
             const messageInfo = JSON.parse(messageData[1]);
-            console.log('Hitting endpoint...');
 
-            // Hit external endpoint.
-            endpoint.hit({
-              'dsn': messageInfo.metadata.dsn,
-              'property_name': messageInfo.metadata.property_name,
-              'data_updated_at': messageInfo.datapoint.updated_at
-            });
+            // Make sure there's actual data before hitting the endpoint.
+            if (messageInfo.datapoint.value !== '') {
+              console.log('Hitting endpoint...');
 
-            // Send the client a message.
-            sendClientsMessage(messageData[1], localWSS);
+              // Hit external endpoint.
+              endpoint.hit({
+                'dsn': messageInfo.metadata.dsn,
+                'property_name': messageInfo.metadata.property_name,
+                'data_updated_at': messageInfo.datapoint.updated_at
+              });
+
+              // Send the client a message.
+              sendClientsMessage(messageData[1], localWSS);
+            }
           }
 
           // If no new messages have been received after 120 seconds


### PR DESCRIPTION
- Adds cachebuster string to get request.
- Make sure old subscription exists before trying to use it.
- Make sure datapoint value from service contains something before hitting endpoint.